### PR TITLE
Ammo name standartization

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -1,3 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+# .20 rifle -> 5.56mm
+# .30 rifle -> 7.62mm
+# .25 caseless -> 7.62mm caseless
+
 # As opposed to MagazineBox these are boxes of magazines so BoxMagazine
 # CaselessRifle
 - type: entity
@@ -12,10 +19,10 @@
       - state: magazine
 
 - type: entity
-  name: box of .25 caseless magazines
+  name: box of 7.62mm caseless magazines
   parent: BoxMagazine
   id: BoxMagazinePistolCaselessRifle
-  description: A box full of .25 caseless magazines.
+  description: A box full of 7.62mm caseless magazines.
   components:
   - type: StorageFill
     contents:
@@ -23,10 +30,10 @@
         amount: 4
 
 - type: entity
-  name: box of .25 caseless (practice) magazines
+  name: box of 7.62mm caseless (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolCaselessRiflePractice
-  description: A box full of .25 caseless practice magazines.
+  description: A box full of 7.62mm caseless practice magazines.
   components:
   - type: StorageFill
     contents:
@@ -34,7 +41,7 @@
         amount: 4
 
 - type: entity
-  name: box of .25 caseless (rubber) magazines
+  name: box of 7.62mm caseless (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazineCaselessRifleRubber
   description: A box full of
@@ -46,10 +53,10 @@
 
 # LightRifle
 - type: entity
-  name: box of .30 rifle magazines
+  name: box of 7.62mm magazines
   parent: BoxMagazine
   id: BoxMagazineLightRifle
-  description: A box full of .30 rifle magazines.
+  description: A box full of 7.62mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -57,10 +64,10 @@
         amount: 4
 
 - type: entity
-  name: box of .30 rifle (practice) magazines
+  name: box of 7.62mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazineLightRiflePractice
-  description: A box full of .30 rifle (practice) magazines.
+  description: A box full of 7.62mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -68,10 +75,10 @@
         amount: 4
 
 - type: entity
-  name: box of .30 rifle (rubber) magazines
+  name: box of 7.62mm (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazineLightRifleRubber
-  description: A box full of .30 rifle (practice) magazines.
+  description: A box full of 7.62mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -113,10 +120,10 @@
 
 # Pistol
 - type: entity
-  name: box of WT550 .35 auto magazines
+  name: box of WT550 9mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGunTopMounted
-  description: A box full of WT550 .35 auto magazines.
+  description: A box full of WT550 9mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -124,10 +131,10 @@
         amount: 3
 
 - type: entity
-  name: box of pistol .35 auto magazines
+  name: box of pistol 9mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistol
-  description: A box full of pistol .35 auto magazines.
+  description: A box full of pistol 9mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -135,7 +142,7 @@
         amount: 4
 
 - type: entity
-  name: box of pistol .35 auto (practice) magazines
+  name: box of pistol 9mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolPractice
   description: A box full of  magazines.
@@ -146,10 +153,10 @@
         amount: 4
 
 - type: entity
-  name: box of pistol .35 auto (rubber) magazines
+  name: box of pistol 9mm (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolRubber
-  description: A box full of pistol .35 auto (rubber) magazines.
+  description: A box full of pistol 9mm (rubber) magazines.
   components:
   - type: StorageFill
     contents:
@@ -157,10 +164,10 @@
         amount: 4
 
 - type: entity
-  name: box of machine pistol .35 auto magazines
+  name: box of machine pistol 9mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolHighCapacity
-  description: A box full of machine pistol .35 auto magazines.
+  description: A box full of machine pistol 9mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -168,10 +175,10 @@
         amount: 4
 
 - type: entity
-  name: box of machine pistol .35 auto (practice) magazines
+  name: box of machine pistol 9mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolHighCapacityPractice
-  description: A box full of machine pistol .35 auto (practice) magazines.
+  description: A box full of machine pistol 9mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -179,10 +186,10 @@
         amount: 4
 
 - type: entity
-  name: box of machine pistol .35 auto (rubber) magazines
+  name: box of machine pistol 9mm (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolHighCapacityRubber
-  description: A box full of machine pistol .35 auto (rubber) magazines.
+  description: A box full of machine pistol 9mm (rubber) magazines.
   components:
   - type: StorageFill
     contents:
@@ -191,10 +198,10 @@
 
 
 - type: entity
-  name: box of SMG .35 auto magazines
+  name: box of SMG 9mm magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGun
-  description: A box full of SMG .35 auto magazines.
+  description: A box full of SMG 9mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -202,10 +209,10 @@
         amount: 3
 
 - type: entity
-  name: box of SMG .35 auto (practice) magazines
+  name: box of SMG 9mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGunPractice
-  description: A box full of SMG .35 auto (practice) magazines.
+  description: A box full of SMG 9mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -213,10 +220,10 @@
         amount: 3
 
 - type: entity
-  name: box of SMG .35 auto (rubber) magazines
+  name: box of SMG 9mm (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazinePistolSubMachineGunRubber
-  description: A box full of SMG .35 auto (rubber) magazines.
+  description: A box full of SMG 9mm (rubber) magazines.
   components:
   - type: StorageFill
     contents:
@@ -270,10 +277,10 @@
 
 # Rifle
 - type: entity
-  name: box of .20 rifle magazines
+  name: box of 5.56mm magazines
   parent: BoxMagazine
   id: BoxMagazineRifle
-  description: A box full of .20 rifle magazines.
+  description: A box full of 5.56mm magazines.
   components:
   - type: StorageFill
     contents:
@@ -281,10 +288,10 @@
         amount: 4
 
 - type: entity
-  name: box of .20 rifle (practice) magazines
+  name: box of 5.56mm (practice) magazines
   parent: BoxMagazine
   id: BoxMagazineRiflePractice
-  description: A box full of .20 rifle (practice) magazines.
+  description: A box full of 5.56mm (practice) magazines.
   components:
   - type: StorageFill
     contents:
@@ -292,10 +299,10 @@
         amount: 4
 
 - type: entity
-  name: box of .20 rifle (rubber) magazines
+  name: box of 5.56mm (rubber) magazines
   parent: BoxMagazine
   id: BoxMagazineRifleRubber
-  description: A box full of .20 rifle (rubber) magazines.
+  description: A box full of 5.56mm (rubber) magazines.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/ammunition.yml
@@ -4,6 +4,7 @@
 # .20 rifle -> 5.56mm
 # .30 rifle -> 7.62mm
 # .25 caseless -> 7.62mm caseless
+# .50 -> 12 gauge
 
 # As opposed to MagazineBox these are boxes of magazines so BoxMagazine
 # CaselessRifle
@@ -232,10 +233,10 @@
 
 # Shotgun
 - type: entity
-  name: box of (.50 pellet) ammo drums
+  name: box of (12 gauge pellet) ammo drums
   parent: BoxMagazine
   id: BoxMagazineShotgun
-  description: A box full of (.50 pellet) ammo drums.
+  description: A box full of (12 gauge pellet) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -243,10 +244,10 @@
         amount: 4
 
 - type: entity
-  name: box of (.50 beanbag) ammo drums
+  name: box of (12 gauge beanbag) ammo drums
   parent: BoxMagazine
   id: BoxMagazineShotgunBeanbag
-  description: A box full of (.50 beanbag) ammo drums.
+  description: A box full of (12 gauge beanbag) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -254,10 +255,10 @@
         amount: 4
 
 - type: entity
-  name: box of (.50 slug) ammo drums
+  name: box of (12 gauge slug) ammo drums
   parent: BoxMagazine
   id: BoxMagazineShotgunSlug
-  description: A box full of (.50 slug) ammo drums.
+  description: A box full of (12 gauge slug) ammo drums.
   components:
   - type: StorageFill
     contents:
@@ -265,10 +266,10 @@
         amount: 4
 
 - type: entity
-  name: box of (.50 incendiary) ammo drums
+  name: box of (12 gauge incendiary) ammo drums
   parent: BoxMagazine
   id: BoxMagazineShotgunIncendiary
-  description: A box full of (.50 incendiary) ammo drums.
+  description: A box full of (12 gauge incendiary) ammo drums.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/caseless_rifle.yml
@@ -1,8 +1,12 @@
+# NT14 Change:
+# Standartization of ammo names
+# .25 caseless -> 7.62mm caseless
+
 - type: entity
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxCaselessRifle
-  name: ammunition box (.25 caseless)
+  name: ammunition box (7.62mm caseless)
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -28,7 +32,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifle10x24
-  name: ammunition box (.25 caseless)
+  name: ammunition box (7.62mm caseless)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -48,7 +52,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifleBig
-  name: ammunition box (.25 caseless)
+  name: ammunition box (7.62mm caseless)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -68,7 +72,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifleBigRubber
-  name: ammunition box (.25 caseless rubber)
+  name: ammunition box (7.62mm caseless rubber)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -89,7 +93,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifle
-  name: ammunition box (.25 caseless)
+  name: ammunition box (7.62mm caseless)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifle
@@ -103,7 +107,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRiflePractice
-  name: ammunition box (.25 caseless practice)
+  name: ammunition box (7.62mm caseless practice)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRiflePractice
@@ -118,7 +122,7 @@
 - type: entity
   parent: BaseMagazineBoxCaselessRifle
   id: MagazineBoxCaselessRifleRubber
-  name: ammunition box (.25 caseless rubber)
+  name: ammunition box (7.62mm caseless rubber)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeCaselessRifleRubber

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/light_rifle.yml
@@ -1,8 +1,12 @@
+# NT14 Change:
+# Standartization of ammo names
+# .30 rifle-> 7.62mm
+
 - type: entity
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxLightRifle
-  name: ammunition box (.30 rifle)
+  name: ammunition box (7.62mm)
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -28,7 +32,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleBig
-  name: ammunition box (.30 rifle)
+  name: ammunition box (7.62mm)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -48,7 +52,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifle
-  name: ammunition box (.30 rifle)
+  name: ammunition box (7.62mm)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifle
@@ -62,7 +66,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRiflePractice
-  name: ammunition box (.30 rifle practice)
+  name: ammunition box (7.62mm practice)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRiflePractice
@@ -77,7 +81,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleRubber
-  name: ammunition box (.30 rifle rubber)
+  name: ammunition box (7.62mm rubber)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleRubber
@@ -92,7 +96,7 @@
 - type: entity
   id: MagazineBoxLightRifleIncendiary
   parent: BaseMagazineBoxLightRifle
-  name: ammunition box (.30 rifle incendiary)
+  name: ammunition box (7.62mm incendiary)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleIncendiary
@@ -107,7 +111,7 @@
 - type: entity
   parent: BaseMagazineBoxLightRifle
   id: MagazineBoxLightRifleUranium
-  name: ammunition box (.30 rifle uranium)
+  name: ammunition box (7.62mm uranium)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeLightRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magnum.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   abstract: true
   parent: BaseItem
@@ -27,7 +31,7 @@
 - type: entity
   parent: BaseMagazineBoxMagnum
   id: MagazineBoxMagnum
-  name: ammunition box (.45 magnum)
+  name: ammunition box (45 Colt)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnum
@@ -41,7 +45,7 @@
 - type: entity
   parent: BaseMagazineBoxMagnum
   id: MagazineBoxMagnumPractice
-  name: ammunition box (.45 magnum practice)
+  name: ammunition box (45 Colt practice)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumPractice
@@ -56,7 +60,7 @@
 - type: entity
   parent: BaseMagazineBoxMagnum
   id: MagazineBoxMagnumRubber
-  name: ammunition box (.45 magnum rubber)
+  name: ammunition box (45 Colt rubber)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumRubber
@@ -71,7 +75,7 @@
 - type: entity
   id: MagazineBoxMagnumIncendiary
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum incendiary)
+  name: ammunition box (45 Colt incendiary)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumIncendiary
@@ -86,7 +90,7 @@
 - type: entity
   id: MagazineBoxMagnumUranium
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum uranium)
+  name: ammunition box (45 Colt uranium)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumUranium
@@ -101,7 +105,7 @@
 - type: entity
   id: MagazineBoxMagnumAP
   parent: BaseMagazineBoxMagnum
-  name: ammunition box (.45 magnum armor-piercing)
+  name: ammunition box (45 Colt armor-piercing)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeMagnumAP

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/pistol.yml
@@ -1,8 +1,12 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   abstract: true
   parent: BaseItem
   id: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto)
+  name: ammunition box (9mm)
   components:
   - type: BallisticAmmoProvider
     mayTransfer: true
@@ -28,7 +32,7 @@
 - type: entity
   parent: BaseMagazineBoxPistol
   id: MagazineBoxPistol
-  name: ammunition box (.35 auto)
+  name: ammunition box (9mm)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistol
@@ -42,7 +46,7 @@
 - type: entity
   parent: BaseMagazineBoxPistol
   id: MagazineBoxPistolPractice
-  name: ammunition box (.35 auto practice)
+  name: ammunition box (9mm practice)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolPractice
@@ -57,7 +61,7 @@
 - type: entity
   parent: BaseMagazineBoxPistol
   id: MagazineBoxPistolRubber
-  name: ammunition box (.35 auto rubber)
+  name: ammunition box (9mm rubber)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolRubber
@@ -72,7 +76,7 @@
 - type: entity
   id: MagazineBoxPistolIncendiary
   parent: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto incendiary)
+  name: ammunition box (9mm incendiary)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolIncendiary
@@ -87,7 +91,7 @@
 - type: entity
   id: MagazineBoxPistolUranium
   parent: BaseMagazineBoxPistol
-  name: ammunition box (.35 auto uranium)
+  name: ammunition box (9mm uranium)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgePistolUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Boxes/rifle.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle -> 5.56mm
+
 - type: entity
   abstract: true
   parent: BaseItem
@@ -27,7 +31,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifleBig
-  name: ammunition box (.20 rifle)
+  name: ammunition box (5.56mm)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -47,7 +51,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifleBigRubber
-  name: ammunition box (.20 rifle rubber)
+  name: ammunition box (5.56mm rubber)
   components:
   - type: BallisticAmmoProvider
     capacity: 200
@@ -68,7 +72,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifle
-  name: ammunition box (.20 rifle)
+  name: ammunition box (5.56mm)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifle
@@ -82,7 +86,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRiflePractice
-  name: ammunition box (.20 rifle practice)
+  name: ammunition box (5.56mm practice)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRiflePractice
@@ -97,7 +101,7 @@
 - type: entity
   parent: BaseMagazineBoxRifle
   id: MagazineBoxRifleRubber
-  name: ammunition box (.20 rifle rubber)
+  name: ammunition box (5.56mm rubber)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleRubber
@@ -112,7 +116,7 @@
 - type: entity
   id: MagazineBoxRifleIncendiary
   parent: BaseMagazineBoxRifle
-  name: ammunition box (.20 rifle incendiary)
+  name: ammunition box (5.56mm incendiary)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleIncendiary
@@ -127,7 +131,7 @@
 - type: entity
   id: MagazineBoxRifleUranium
   parent: BaseMagazineBoxRifle
-  name: ammunition box (.20 rifle uranium)
+  name: ammunition box (5.56mm uranium)
   components:
   - type: BallisticAmmoProvider
     proto: CartridgeRifleUranium

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/caseless_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .25 caseless -> 7.62mm caseless
+
 - type: entity
   id: BaseCartridgeCaselessRifle
-  name: cartridge (.25 rifle)
+  name: cartridge (7.62mm caseless rifle) #Wasn't .25 caseless but just .25, but im changing it too because idk
   parent: BaseCartridge
   abstract: true
   components:
@@ -23,7 +27,7 @@
 
 - type: entity
   id: CartridgeCaselessRifle
-  name: cartridge (.25 caseless)
+  name: cartridge (7.62mm caseless)
   parent: BaseCartridgeCaselessRifle
   components:
   - type: CartridgeAmmo
@@ -31,7 +35,7 @@
 
 - type: entity
   id: CartridgeCaselessRiflePractice
-  name: cartridge (.25 caseless practice)
+  name: cartridge (7.62mm caseless practice)
   parent: BaseCartridgeCaselessRifle
   components:
   - type: CartridgeAmmo
@@ -39,7 +43,7 @@
 
 - type: entity
   id: CartridgeCaselessRifleRubber
-  name: cartridge (.25 caseless rubber)
+  name: cartridge (7.62mm caseless rubber)
   parent: BaseCartridgeCaselessRifle
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/heavy_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle-> 5.56mm
+
 - type: entity
   id: BaseCartridgeHeavyRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56mm)
   parent: BaseCartridge
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/light_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .30 rifle-> 7.62mm
+
 - type: entity
   id: BaseCartridgeLightRifle
-  name: cartridge (.30 rifle)
+  name: cartridge (7.62mm)
   parent: BaseCartridge
   abstract: true
   components:
@@ -20,7 +24,7 @@
 
 - type: entity
   id: CartridgeLightRifle
-  name: cartridge (.30 rifle)
+  name: cartridge (7.62mm)
   parent: BaseCartridgeLightRifle
   components:
   - type: CartridgeAmmo
@@ -28,7 +32,7 @@
 
 - type: entity
   id: CartridgeLightRiflePractice
-  name: cartridge (.30 rifle practice)
+  name: cartridge (7.62mm practice)
   parent: BaseCartridgeLightRifle
   components:
   - type: CartridgeAmmo
@@ -36,7 +40,7 @@
 
 - type: entity
   id: CartridgeLightRifleRubber
-  name: cartridge (.30 rifle rubber)
+  name: cartridge (7.62mm rubber)
   parent: BaseCartridgeLightRifle
   components:
   - type: CartridgeAmmo
@@ -44,7 +48,7 @@
 
 - type: entity
   id: CartridgeLightRifleIncendiary
-  name: cartridge (.30 rifle incendiary)
+  name: cartridge (7.62mm incendiary)
   parent: BaseCartridgeLightRifle
   components:
   - type: CartridgeAmmo
@@ -52,7 +56,7 @@
 
 - type: entity
   id: CartridgeLightRifleUranium
-  name: cartridge (.30 rifle uranium)
+  name: cartridge (7.62mm uranium)
   parent: BaseCartridgeLightRifle
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/magnum.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   id: BaseCartridgeMagnum
-  name: cartridge (.45 magnum)
+  name: cartridge (45 Colt)
   parent: BaseCartridge
   abstract: true
   components:
@@ -20,7 +24,7 @@
 
 - type: entity
   id: CartridgeMagnum
-  name: cartridge (.45 magnum)
+  name: cartridge (45 Colt)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo
@@ -28,7 +32,7 @@
 
 - type: entity
   id: CartridgeMagnumPractice
-  name: cartridge (.45 magnum practice)
+  name: cartridge (45 Colt practice)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo
@@ -36,7 +40,7 @@
 
 - type: entity
   id: CartridgeMagnumRubber
-  name: cartridge (.45 magnum rubber)
+  name: cartridge (45 Colt rubber)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo
@@ -44,7 +48,7 @@
 
 - type: entity
   id: CartridgeMagnumIncendiary
-  name: cartridge (.45 magnum incendiary)
+  name: cartridge (45 Colt incendiary)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo
@@ -52,7 +56,7 @@
 
 - type: entity
   id: CartridgeMagnumAP
-  name: cartridge (.45 magnum armor-piercing)
+  name: cartridge (45 Colt armor-piercing)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo
@@ -60,7 +64,7 @@
 
 - type: entity
   id: CartridgeMagnumUranium
-  name: cartridge (.45 magnum uranium)
+  name: cartridge (45 Colt uranium)
   parent: BaseCartridgeMagnum
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/pistol.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   id: BaseCartridgePistol
-  name: cartridge (.35 auto)
+  name: cartridge (9mm)
   parent: BaseCartridge
   abstract: true
   components:
@@ -20,7 +24,7 @@
 
 - type: entity
   id: CartridgePistol
-  name: cartridge (.35 auto)
+  name: cartridge (9mm)
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -28,7 +32,7 @@
 
 - type: entity
   id: CartridgePistolPractice
-  name: cartridge (.35 auto practice)
+  name: cartridge (9mm practice)
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -36,7 +40,7 @@
 
 - type: entity
   id: CartridgePistolRubber
-  name: cartridge (.35 auto rubber)
+  name: cartridge (9mm rubber)
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -44,7 +48,7 @@
 
 - type: entity
   id: CartridgePistolIncendiary
-  name: cartridge (.35 auto incendiary)
+  name: cartridge (9mm incendiary)
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo
@@ -52,7 +56,7 @@
 
 - type: entity
   id: CartridgePistolUranium
-  name: cartridge (.35 auto uranium)
+  name: cartridge (9mm uranium)
   parent: BaseCartridgePistol
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle -> 5.56mm
+
 - type: entity
   id: BaseCartridgeRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56mm)
   parent: BaseCartridge
   abstract: true
   components:
@@ -20,7 +24,7 @@
 
 - type: entity
   id: CartridgeRifle
-  name: cartridge (.20 rifle)
+  name: cartridge (5.56mm)
   parent: BaseCartridgeRifle
   components:
   - type: CartridgeAmmo
@@ -28,7 +32,7 @@
 
 - type: entity
   id: CartridgeRiflePractice
-  name: cartridge (.20 rifle practice)
+  name: cartridge (5.56mm practice)
   parent: BaseCartridgeRifle
   components:
   - type: CartridgeAmmo
@@ -36,7 +40,7 @@
 
 - type: entity
   id: CartridgeRifleRubber
-  name: cartridge (.20 rifle rubber)
+  name: cartridge (5.56mm rubber)
   parent: BaseCartridgeRifle
   components:
   - type: CartridgeAmmo
@@ -44,7 +48,7 @@
 
 - type: entity
   id: CartridgeRifleIncendiary
-  name: cartridge (.20 rifle incendiary)
+  name: cartridge (5.56mm incendiary)
   parent: BaseCartridgeRifle
   components:
   - type: CartridgeAmmo
@@ -52,7 +56,7 @@
 
 - type: entity
   id: CartridgeRifleUranium
-  name: cartridge (.20 rifle uranium)
+  name: cartridge (5.56mm uranium)
   parent: BaseCartridgeRifle
   components:
   - type: CartridgeAmmo

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Cartridges/shotgun.yml
@@ -1,6 +1,10 @@
-﻿- type: entity
+﻿# NT14 Change:
+# Standartization of ammo names
+# .50 -> 12 gauge
+
+- type: entity
   id: BaseShellShotgun
-  name: shell (.50)
+  name: shell (12 gauge)
   parent: BaseCartridge
   abstract: true
   components:
@@ -23,7 +27,7 @@
 
 - type: entity
   id: ShellShotgunBeanbag
-  name: shell (.50 beanbag)
+  name: shell (12 gauge beanbag)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -38,7 +42,7 @@
 
 - type: entity
   id: ShellShotgunSlug
-  name: shell (.50 slug)
+  name: shell (12 gauge slug)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -54,7 +58,7 @@
 
 - type: entity
   id: ShellShotgunFlare
-  name: shell (.50 flare)
+  name: shell (12 gauge flare)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -69,7 +73,7 @@
 
 - type: entity
   id: ShellShotgun
-  name: shell (.50)
+  name: shell (12 gauge)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -81,7 +85,7 @@
 
 - type: entity
   id: ShellShotgunIncendiary
-  name: shell (.50 incendiary)
+  name: shell (12 gauge incendiary)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -95,7 +99,7 @@
 
 - type: entity
   id: ShellShotgunPractice
-  name: shell (.50 practice)
+  name: shell (12 gauge practice)
   parent: BaseShellShotgun
   components:
   - type: Sprite
@@ -109,7 +113,7 @@
 
 - type: entity
   id: ShellTranquilizer
-  name: shell (.50 tranquilizer)
+  name: shell (12 gauge tranquilizer)
   parent: BaseShellShotgun
   components:
   - type: Sprite

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .25 caseless -> 7.62mm caseless
+
 - type: entity
   id: BaseMagazineCaselessRifle
-  name: "magazine (.25 caseless)"
+  name: "magazine (7.62mm caseless)"
   parent: BaseItem
   abstract: true
   components:
@@ -34,7 +38,7 @@
 
 - type: entity
   id: BaseMagazineCaselessRifleShort
-  name: "caseless rifle short magazine (.25 caseless)"
+  name: "caseless rifle short magazine (7.62mm caseless)"
   parent: BaseMagazineCaselessRifle
   abstract: true
   components:
@@ -53,7 +57,7 @@
 
 - type: entity
   id: BaseMagazinePistolCaselessRifle
-  name: "pistol magazine (.25 caseless)"
+  name: "pistol magazine (7.62mm caseless)"
   parent: BaseMagazineCaselessRifle
   abstract: true
   components:
@@ -83,7 +87,7 @@
 
 - type: entity
   id: MagazineCaselessRifle10x24
-  name: "box magazine (.25 caseless)"
+  name: "box magazine (7.62mm caseless)"
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -94,7 +98,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRifle
-  name: "pistol magazine (.25 caseless)"
+  name: "pistol magazine (7.62mm caseless)"
   parent: BaseMagazinePistolCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -114,7 +118,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRiflePractice
-  name: "pistol magazine (.25 caseless practice)"
+  name: "pistol magazine (7.62mm caseless practice)"
   parent: BaseMagazinePistolCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -134,7 +138,7 @@
 
 - type: entity
   id: MagazinePistolCaselessRifleRubber
-  name: "pistol magazine (.25 caseless rubber)"
+  name: "pistol magazine (7.62mm caseless rubber)"
   parent: BaseMagazinePistolCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -154,7 +158,7 @@
 
 - type: entity
   id: MagazineCaselessRifle
-  name: "magazine (.25 caseless)"
+  name: "magazine (7.62mm caseless)"
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -168,7 +172,7 @@
 
 - type: entity
   id: MagazineCaselessRiflePractice
-  name: "magazine (.25 caseless practice)"
+  name: "magazine (7.62mm caseless practice)"
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -182,7 +186,7 @@
 
 - type: entity
   id: MagazineCaselessRifleRubber
-  name: "magazine (.25 caseless rubber)"
+  name: "magazine (7.62mm caseless rubber)"
   parent: BaseMagazineCaselessRifle
   components:
   - type: BallisticAmmoProvider
@@ -196,7 +200,7 @@
 
 - type: entity
   id: MagazineCaselessRifleShort
-  name: "short magazine (.25 caseless)"
+  name: "short magazine (7.62mm caseless)"
   parent: BaseMagazineCaselessRifleShort
   components:
   - type: BallisticAmmoProvider
@@ -211,7 +215,7 @@
 
 - type: entity
   id: MagazineCaselessRifleShortPractice
-  name: "short magazine (.25 caseless practice)"
+  name: "short magazine (7.62mm caseless practice)"
   parent: BaseMagazineCaselessRifleShort
   components:
   - type: BallisticAmmoProvider
@@ -226,7 +230,7 @@
 
 - type: entity
   id: MagazineCaselessRifleShortRubber
-  name: "short magazine (.25 caseless rubber)"
+  name: "short magazine (7.62mm caseless rubber)"
   parent: BaseMagazineCaselessRifleShort
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/heavy_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle-> 5.56mm
+
 - type: entity
   id: BaseMagazineHeavyRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56mm)"
   parent: BaseItem
   abstract: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -1,7 +1,11 @@
+# NT14 Change:
+# Standartization of ammo names
+# .30 rifle-> 7.62mm
+
 # Empty mags
 - type: entity
   id: BaseMagazineLightRifle
-  name: "magazine (.30 rifle)"
+  name: "magazine (7.62mm)"
   parent: BaseItem
   abstract: true
   components:
@@ -36,7 +40,7 @@
 # Magazines
 - type: entity
   id: MagazineLightRifleBox
-  name: "L6 SAW magazine box (.30 rifle)"
+  name: "L6 SAW magazine box (7.62mm)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag
@@ -56,7 +60,7 @@
 
 - type: entity
   id: MagazineLightRifle
-  name: "magazine (.30 rifle)"
+  name: "magazine (7.62mm)"
   parent: BaseMagazineLightRifle
   components:
   - type: BallisticAmmoProvider
@@ -70,7 +74,7 @@
 
 - type: entity
   id: MagazineLightRiflePractice
-  name: "magazine (.30 rifle practice)"
+  name: "magazine (7.62mm practice)"
   parent: BaseMagazineLightRifle
   components:
   - type: BallisticAmmoProvider
@@ -84,7 +88,7 @@
 
 - type: entity
   id: MagazineLightRifleRubber
-  name: "magazine (.30 rifle rubber)"
+  name: "magazine (7.62mm rubber)"
   parent: BaseMagazineLightRifle
   components:
   - type: BallisticAmmoProvider
@@ -98,7 +102,7 @@
 
 - type: entity
   id: MagazineLightRifleUranium
-  name: "magazine (.30 rifle uranium)"
+  name: "magazine (7.62mm uranium)"
   parent: BaseMagazineLightRifle
   components:
   - type: BallisticAmmoProvider
@@ -112,7 +116,7 @@
 
 - type: entity
   id: MagazineLightRifleMaxim
-  name: "pan magazine (.30 rifle)"
+  name: "pan magazine (7.62mm)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag
@@ -126,7 +130,7 @@
 
 - type: entity
   id: MagazineLightRiflePkBox
-  name: "PK munitions box (.30 rifle)"
+  name: "PK munitions box (7.62mm)"
   parent: BaseMagazineLightRifle
   components:
   - type: Tag

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/magnum.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   id: BaseMagazineMagnum
-  name: pistol magazine (.45 magnum)
+  name: pistol magazine (45 Colt)
   parent: BaseMagazinePistol
   abstract: true
   components:
@@ -16,7 +20,7 @@
 
 - type: entity
   id: BaseMagazineMagnumSubMachineGun
-  name: "Vector magazine (.45 magnum)"
+  name: "Vector magazine (45 Colt)"
   parent: BaseItem
   abstract: true
   components:
@@ -49,7 +53,7 @@
 
 - type: entity
   id: MagazineMagnum
-  name: pistol magazine (.45 magnum)
+  name: pistol magazine (45 Colt)
   parent: BaseMagazineMagnum
   components:
   - type: BallisticAmmoProvider
@@ -63,7 +67,7 @@
 
 - type: entity
   id: MagazineMagnumPractice
-  name: pistol magazine (.45 magnum practice)
+  name: pistol magazine (45 Colt practice)
   parent: BaseMagazineMagnum
   components:
   - type: BallisticAmmoProvider
@@ -77,7 +81,7 @@
 
 - type: entity
   id: MagazineMagnumRubber
-  name: pistol magazine (.45 magnum rubber)
+  name: pistol magazine (45 Colt rubber)
   parent: BaseMagazineMagnum
   components:
   - type: BallisticAmmoProvider
@@ -91,7 +95,7 @@
 
 - type: entity
   id: MagazineMagnumUranium
-  name: pistol magazine (.45 magnum uranium)
+  name: pistol magazine (45 Colt uranium)
   parent: BaseMagazineMagnum
   components:
   - type: BallisticAmmoProvider
@@ -105,7 +109,7 @@
 
 - type: entity
   id: MagazineMagnumAP
-  name: pistol magazine (.45 magnum armor-piercing)
+  name: pistol magazine (45 Colt armor-piercing)
   parent: BaseMagazineMagnum
   components:
   - type: BallisticAmmoProvider
@@ -119,7 +123,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGun
-  name: "Vector magazine (.45 magnum)"
+  name: "Vector magazine (45 Colt)"
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -133,7 +137,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunPractice
-  name: "Vector magazine (.45 magnum practice)"
+  name: "Vector magazine (45 Colt practice)"
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -147,7 +151,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunRubber
-  name: "Vector magazine (.45 magnum rubber)"
+  name: "Vector magazine (45 Colt rubber)"
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -161,7 +165,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunUranium
-  name: "Vector magazine (.45 magnum uranium)"
+  name: "Vector magazine (45 Colt uranium)"
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -175,7 +179,7 @@
 
 - type: entity
   id: MagazineMagnumSubMachineGunPiercing
-  name: "Vector magazine (.45 magnum armor-piercing)"
+  name: "Vector magazine (45 Colt armor-piercing)"
   parent: BaseMagazineMagnumSubMachineGun
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/pistol.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   id: BaseMagazinePistol
-  name: pistol magazine (.35 auto)
+  name: pistol magazine (9mm)
   parent: BaseItem
   abstract: true
   components:
@@ -33,7 +37,7 @@
 
 - type: entity
   id: BaseMagazinePistolHighCapacity
-  name: machine pistol magazine (.35 auto)
+  name: machine pistol magazine (9mm)
   parent: BaseItem
   abstract: true
   components:
@@ -66,7 +70,7 @@
 
 - type: entity
   id: BaseMagazinePistolSubMachineGun  # Yeah it's weird but it's pistol caliber
-  name: SMG magazine (.35 auto)
+  name: SMG magazine (9mm)
   parent: BaseItem
   abstract: true
   components:
@@ -99,7 +103,7 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunTopMounted
-  name: WT550 magazine (.35 auto top-mounted)
+  name: WT550 magazine (9mm top-mounted)
   parent: BaseItem
   components:
   - type: Tag
@@ -130,7 +134,7 @@
 
 - type: entity
   id: MagazinePistol
-  name: pistol magazine (.35 auto)
+  name: pistol magazine (9mm)
   parent: BaseMagazinePistol
   components:
   - type: BallisticAmmoProvider
@@ -144,7 +148,7 @@
 
 - type: entity
   id: MagazinePistolPractice
-  name: pistol magazine (.35 auto practice)
+  name: pistol magazine (9mm practice)
   parent: BaseMagazinePistol
   components:
   - type: BallisticAmmoProvider
@@ -158,7 +162,7 @@
 
 - type: entity
   id: MagazinePistolRubber
-  name: pistol magazine (.35 auto rubber)
+  name: pistol magazine (9mm rubber)
   parent: BaseMagazinePistol
   components:
   - type: BallisticAmmoProvider
@@ -172,7 +176,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacity
-  name: machine pistol magazine (.35 auto)
+  name: machine pistol magazine (9mm)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -186,7 +190,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityPractice
-  name: machine pistol magazine (.35 auto practice)
+  name: machine pistol magazine (9mm practice)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -200,7 +204,7 @@
 
 - type: entity
   id: MagazinePistolHighCapacityRubber
-  name: machine pistol magazine (.35 auto rubber)
+  name: machine pistol magazine (9mm rubber)
   parent: BaseMagazinePistolHighCapacity
   components:
   - type: BallisticAmmoProvider
@@ -214,7 +218,7 @@
 
 - type: entity
   id: MagazinePistolSubMachineGun
-  name: SMG magazine (.35 auto)
+  name: SMG magazine (9mm)
   parent: BaseMagazinePistolSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -234,7 +238,7 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunPractice
-  name: SMG magazine (.35 auto practice)
+  name: SMG magazine (9mm practice)
   parent: BaseMagazinePistolSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -248,7 +252,7 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunRubber
-  name: SMG magazine (.35 auto rubber)
+  name: SMG magazine (9mm rubber)
   parent: BaseMagazinePistolSubMachineGun
   components:
   - type: BallisticAmmoProvider
@@ -262,7 +266,7 @@
 
 - type: entity
   id: MagazinePistolSubMachineGunUranium
-  name: SMG magazine (.35 auto rubber)
+  name: SMG magazine (9mm rubber)
   parent: BaseMagazinePistolSubMachineGun
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/rifle.yml
@@ -1,7 +1,11 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle -> 5.56mm
+
 # Empty mags
 - type: entity
   id: BaseMagazineRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56mm)"
   parent: BaseItem
   abstract: true
   components:
@@ -35,7 +39,7 @@
 # Magazines
 - type: entity
   id: MagazineRifle
-  name: "magazine (.20 rifle)"
+  name: "magazine (5.56mm)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -49,7 +53,7 @@
 
 - type: entity
   id: MagazineRiflePractice
-  name: "magazine (.20 rifle practice)"
+  name: "magazine (5.56mm practice)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -63,7 +67,7 @@
 
 - type: entity
   id: MagazineRifleRubber
-  name: "magazine (.20 rifle rubber)"
+  name: "magazine (5.56mm rubber)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider
@@ -77,7 +81,7 @@
 
 - type: entity
   id: MagazineRifleUranium
-  name: "magazine (.20 rifle uranium)"
+  name: "magazine (5.56mm uranium)"
   parent: BaseMagazineRifle
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/shotgun.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .50 -> 12 gauge
+
 - type: entity
   id: BaseMagazineShotgun
-  name: ammo drum (.50 shells)
+  name: ammo drum (12 gauge shells)
   parent: BaseItem
   abstract: true
   components:
@@ -35,7 +39,7 @@
 
 - type: entity
   id: MagazineShotgun
-  name: ammo drum (.50 pellet)
+  name: ammo drum (12 gauge pellet)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -49,7 +53,7 @@
 
 - type: entity
   id: MagazineShotgunBeanbag
-  name: ammo drum (.50 beanbags)
+  name: ammo drum (12 gauge beanbags)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -63,7 +67,7 @@
 
 - type: entity
   id: MagazineShotgunSlug
-  name: ammo drum (.50 slug)
+  name: ammo drum (12 gauge slug)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider
@@ -77,7 +81,7 @@
 
 - type: entity
   id: MagazineShotgunIncendiary
-  name: ammo drum (.50 incendiary)
+  name: ammo drum (12 gauge incendiary)
   parent: BaseMagazineShotgun
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/caseless_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .25 caseless -> 7.62mm caseless
+
 - type: entity
   id: BulletCaselessRifle
-  name: bullet (.25 caseless)
+  name: bullet (7.62mm caseless)
   parent: BaseBullet
   noSpawn: true
   components:
@@ -11,7 +15,7 @@
 
 - type: entity
   id: BulletCaselessRiflePractice
-  name: bullet (.25 caseless practice)
+  name: bullet (7.62mm caseless practice)
   parent: BaseBulletPractice
   noSpawn: true
   components:
@@ -22,7 +26,7 @@
 
 - type: entity
   id: BulletCaselessRifleRubber
-  name: bullet (.25 caseless rubber)
+  name: bullet (7.62mm caseless rubber)
   parent: BaseBulletRubber
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/heavy_rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle-> 5.56mm
+
 - type: entity
   id: BulletHeavyRifle
-  name: bullet (.20 rifle)
+  name: bullet (5.56mm)
   parent: BaseBullet
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/magnum.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   id: BulletMagnum
-  name: bullet (.45 magnum)
+  name: bullet (45 Colt)
   parent: BaseBullet
   noSpawn: true
   components:
@@ -11,7 +15,7 @@
 
 - type: entity
   id: BulletMagnumPractice
-  name: bullet (.45 magnum practice)
+  name: bullet (45 Colt practice)
   parent: BaseBulletPractice
   noSpawn: true
   components:
@@ -22,7 +26,7 @@
 
 - type: entity
   id: BulletMagnumRubber
-  name: bullet (.45 magnum rubber)
+  name: bullet (45 Colt rubber)
   parent: BaseBulletRubber
   noSpawn: true
   components:
@@ -36,7 +40,7 @@
 - type: entity
   id: BulletMagnumIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (.45 magnum incendiary)
+  name: bullet (45 Colt incendiary)
   noSpawn: true
   components:
   - type: Projectile
@@ -47,7 +51,7 @@
         
 - type: entity
   id: BulletMagnumAP
-  name: bullet (.45 magnum armor-piercing)
+  name: bullet (45 Colt armor-piercing)
   parent: BaseBulletAP
   noSpawn: true
   components:
@@ -59,7 +63,7 @@
 
 - type: entity
   id: BulletMagnumUranium
-  name: bullet (.45 magnum uranium)
+  name: bullet (45 Colt uranium)
   parent: BaseBulletUranium
   noSpawn: true
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/pistol.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   id: BulletPistol
-  name: bullet (.35 auto)
+  name: bullet (9mm)
   parent: BaseBullet
   noSpawn: true
   components:
@@ -11,7 +15,7 @@
 
 - type: entity
   id: BulletPistolPractice
-  name: bullet (.35 auto practice)
+  name: bullet (9mm practice)
   parent: BaseBulletPractice
   noSpawn: true
   components:
@@ -22,7 +26,7 @@
 
 - type: entity
   id: BulletPistolRubber
-  name: bullet (.35 auto rubber)
+  name: bullet (9mm rubber)
   parent: BaseBulletRubber
   noSpawn: true
   components:
@@ -34,7 +38,7 @@
 - type: entity
   id: BulletPistolIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (.35 auto incendiary)
+  name: bullet (9mm incendiary)
   noSpawn: true
   components:
   - type: Projectile
@@ -46,7 +50,7 @@
 - type: entity
   id: BulletPistolUranium
   parent: BaseBulletUranium
-  name: bullet (.35 auto uranium)
+  name: bullet (9mm uranium)
   noSpawn: true
   components:
   - type: Projectile

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/rifle.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle -> 5.56mm
+
 - type: entity
   id: BulletRifle
-  name: bullet (0.20 rifle)
+  name: bullet (5.56mm)
   parent: BaseBullet
   noSpawn: true
   components:
@@ -11,7 +15,7 @@
 
 - type: entity
   id: BulletRiflePractice
-  name: bullet (0.20 rifle practice)
+  name: bullet (5.56mm practice)
   parent: BaseBulletPractice
   noSpawn: true
   components:
@@ -22,7 +26,7 @@
 
 - type: entity
   id: BulletRifleRubber
-  name: bullet (0.20 rifle rubber)
+  name: bullet (5.56mm rubber)
   parent: BaseBulletRubber
   noSpawn: true
   components:
@@ -34,7 +38,7 @@
 - type: entity
   id: BulletRifleIncendiary
   parent: BaseBulletIncendiary
-  name: bullet (0.20 rifle incendiary)
+  name: bullet (5.56mm incendiary)
   noSpawn: true
   components:
   - type: Projectile
@@ -46,7 +50,7 @@
 - type: entity
   id: BulletRifleUranium
   parent: BaseBulletUranium
-  name: bullet (0.20 rifle uranium)
+  name: bullet (5.56mm uranium)
   noSpawn: true
   components:
   - type: Projectile

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/shotgun.yml
@@ -1,6 +1,10 @@
-﻿- type: entity
+﻿# NT14 Change:
+# Standartization of ammo names
+# .50 -> 12 gauge
+
+- type: entity
   id: PelletShotgunSlug
-  name: pellet (.50 slug)
+  name: pellet (12 gauge slug)
   noSpawn: true
   parent: BaseBullet
   components:
@@ -14,7 +18,7 @@
 
 - type: entity
   id: PelletShotgunBeanbag
-  name: beanbag (.50)
+  name: beanbag (12 gauge)
   noSpawn: true
   parent: BaseBullet
   components:
@@ -30,7 +34,7 @@
 
 - type: entity
   id: PelletShotgun
-  name: pellet (.50)
+  name: pellet (12 gauge)
   noSpawn: true
   parent: BaseBullet
   components:
@@ -44,7 +48,7 @@
 
 - type: entity
   id: PelletShotgunIncendiary
-  name: pellet (.50 incendiary)
+  name: pellet (12 gauge incendiary)
   noSpawn: true
   parent: BaseBulletIncendiary
   components:
@@ -61,7 +65,7 @@
 
 - type: entity
   id: PelletShotgunPractice
-  name: pellet (.50 practice)
+  name: pellet (12 gauge practice)
   noSpawn: true
   parent: BaseBulletPractice
   components:
@@ -90,7 +94,7 @@
 
 - type: entity
   id: PelletShotgunTranquilizer
-  name: pellet (.50 tranquilizer)
+  name: pellet (12 gauge tranquilizer)
   noSpawn: true
   parent: BaseBulletPractice
   components:
@@ -117,7 +121,7 @@
 
 - type: entity
   id: PelletShotgunFlare
-  name: pellet (.50 flare)
+  name: pellet (12 gauge flare)
   noSpawn: true
   components:
   - type: Physics
@@ -167,7 +171,7 @@
 
 - type: entity
   id: PelletShotgunUranium
-  name: pellet (.50 uranium)
+  name: pellet (12 gauge uranium)
   noSpawn: true
   parent: BaseBullet
   components:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/magnum.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   id: BaseSpeedLoaderMagnum
-  name: "speed loader (.45 magnum)"
+  name: "speed loader (45 Colt)"
   parent: BaseItem
   abstract: true
   components:
@@ -21,7 +25,7 @@
 
 - type: entity
   id: SpeedLoaderMagnum
-  name: "speed loader (.45 magnum)"
+  name: "speed loader (45 Colt)"
   parent: BaseSpeedLoaderMagnum
   components:
   - type: BallisticAmmoProvider
@@ -41,7 +45,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumPractice
-  name: "speed loader (.45 magnum practice)"
+  name: "speed loader (45 Colt practice)"
   parent: BaseSpeedLoaderMagnum
   components:
   - type: BallisticAmmoProvider
@@ -61,7 +65,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumRubber
-  name: "speed loader (.45 magnum rubber)"
+  name: "speed loader (45 Colt rubber)"
   parent: BaseSpeedLoaderMagnum
   components:
   - type: BallisticAmmoProvider
@@ -81,7 +85,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumAP
-  name: "speed loader (.45 magnum armor-piercing)"
+  name: "speed loader (45 Colt armor-piercing)"
   parent: BaseSpeedLoaderMagnum
   components:
   - type: BallisticAmmoProvider
@@ -101,7 +105,7 @@
 
 - type: entity
   id: SpeedLoaderMagnumUranium
-  name: "speed loader (.45 magnum uranium)"
+  name: "speed loader (45 Colt uranium)"
   parent: BaseSpeedLoaderMagnum
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/SpeedLoaders/pistol.yml
@@ -1,6 +1,10 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   id: BaseSpeedLoaderPistol
-  name: "speed loader (.35 auto)"
+  name: "speed loader (9mm)"
   parent: BaseItem
   abstract: true
   components:
@@ -22,7 +26,7 @@
 
 - type: entity
   id: SpeedLoaderPistol
-  name: "speed loader (.35 auto)"
+  name: "speed loader (9mm)"
   parent: BaseSpeedLoaderPistol
   components:
   - type: BallisticAmmoProvider
@@ -41,7 +45,7 @@
 
 - type: entity
   id: SpeedLoaderPistolPractice
-  name: "speed loader (.35 auto practice)"
+  name: "speed loader (9mm practice)"
   parent: BaseSpeedLoaderPistol
   components:
   - type: BallisticAmmoProvider
@@ -60,7 +64,7 @@
 
 - type: entity
   id: SpeedLoaderPistolRubber
-  name: "speed loader (.35 auto rubber)"
+  name: "speed loader (9mm rubber)"
   parent: BaseSpeedLoaderPistol
   components:
   - type: BallisticAmmoProvider

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .30 rifle-> 7.62mm
+
 - type: entity
   name: BaseWeaponLightMachineGun
   parent: BaseItem
@@ -65,7 +69,7 @@
   name: L6 SAW
   id: WeaponLightMachineGunL6
   parent: BaseWeaponLightMachineGun
-  description: A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. Uses .30 rifle ammo.
+  description: A rather traditionally made LMG with a pleasantly lacquered wooden pistol grip. Uses 7.62mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/LMGs/l6.rsi
@@ -84,7 +88,7 @@
   name: L6C ROW
   id: WeaponLightMachineGunL6C
   parent: BaseItem
-  description: A L6 SAW for use by cyborgs. Creates .30 rifle ammo on the fly from an internal ammo fabricator, which slowly self-charges.
+  description: A L6 SAW for use by cyborgs. Creates 7.62mm ammo on the fly from an internal ammo fabricator, which slowly self-charges.
   components:
     - type: Gun
       minAngle: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Pistols/pistols.yml
@@ -1,3 +1,8 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+# .25 caseless -> 7.62mm caseless
+
 - type: entity
   name: BasePistol
   parent: BaseItem
@@ -70,7 +75,7 @@
   name: viper
   parent: BaseWeaponPistol
   id: WeaponPistolViper
-  description: A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses .35 auto ammo.
+  description: A small, easily concealable, but somewhat underpowered gun. Retrofitted with a fully automatic receiver. Uses 9mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/viper.rsi
@@ -105,7 +110,7 @@
   name: cobra
   parent: BaseWeaponPistol
   id: WeaponPistolCobra
-  description: A rugged, robust operator handgun with inbuilt silencer. Uses .25 caseless ammo.
+  description: A rugged, robust operator handgun with inbuilt silencer. Uses 7.62mm caseless ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/cobra.rsi
@@ -153,7 +158,7 @@
   name: mk 58
   parent: BaseWeaponPistol
   id: WeaponPistolMk58
-  description: A cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Uses .35 auto ammo.
+  description: A cheap, ubiquitous sidearm, produced by a NanoTrasen subsidiary. Uses 9mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Pistols/mk58.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .45 magnum -> 45 Colt
+
 - type: entity
   name: BaseWeaponRevolver
   parent: BaseItem
@@ -54,7 +58,7 @@
   name: Deckard
   parent: BaseWeaponRevolver
   id: WeaponRevolverDeckard
-  description: A rare, custom-built revolver. Use when there is no time for Voight-Kampff test. Uses .45 magnum ammo.
+  description: A rare, custom-built revolver. Use when there is no time for Voight-Kampff test. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -82,7 +86,7 @@
   name: Inspector
   parent: BaseWeaponRevolver
   id: WeaponRevolverInspector
-  description: A detective's best friend. Uses .45 magnum ammo.
+  description: A detective's best friend. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/inspector.rsi
@@ -97,7 +101,7 @@
   name: Mateba
   parent: BaseWeaponRevolver
   id: WeaponRevolverMateba
-  description: The iconic sidearm of the dreaded death squads. Uses .45 magnum ammo.
+  description: The iconic sidearm of the dreaded death squads. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/mateba.rsi
@@ -112,7 +116,7 @@
   name: Python
   parent: BaseWeaponRevolver
   id: WeaponRevolverPython
-  description: A robust revolver favoured by Syndicate agents. Uses .45 magnum ammo.
+  description: A robust revolver favoured by Syndicate agents. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/python.rsi
@@ -133,7 +137,7 @@
   parent: WeaponRevolverPython
   id: WeaponRevolverPythonAP # For the uplink.
   suffix: armor-piercing
-  description: A robust revolver favoured by Syndicate agents. Uses .45 magnum ammo.
+  description: A robust revolver favoured by Syndicate agents. Uses 45 Colt ammo.
   components:
   - type: RevolverAmmoProvider
     whitelist:
@@ -147,7 +151,7 @@
   name: pirate revolver
   parent: BaseWeaponRevolver
   id: WeaponRevolverPirate
-  description: An odd, old-looking revolver, favoured by pirate crews. Uses .45 magnum ammo.
+  description: An odd, old-looking revolver, favoured by pirate crews. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/pirate_revolver.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,3 +1,8 @@
+# NT14 Change:
+# Standartization of ammo names
+# .20 rifle-> 5.56mm
+# .30 rifle -> 7.62mm
+
 - type: entity
   name: BaseWeaponRifle
   parent: BaseItem
@@ -54,7 +59,7 @@
   name: AKMS
   parent: BaseWeaponRifle
   id: WeaponRifleAk
-  description: An iconic weapon of war. Uses .30 rifle ammo.
+  description: An iconic weapon of war. Uses 7.62mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/ak.rsi
@@ -102,7 +107,7 @@
   name: M-90gl
   parent: BaseWeaponRifle
   id: WeaponRifleM90GrenadeLauncher
-  description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses .20 rifle ammo.
+  description: An older bullpup carbine model, with an attached underbarrel grenade launcher. Uses 5.56mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/carbine.rsi
@@ -145,7 +150,7 @@
   name: Lecter
   parent: BaseWeaponRifle
   id: WeaponRifleLecter
-  description: A high end military grade assault rifle. Uses .20 rifle ammo.
+  description: A high end military grade assault rifle. Uses 5.56mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Rifles/lecter.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,6 +1,7 @@
 # NT14 Change:
 # Standartization of ammo names
 # .35 auto -> 9mm
+# .45 magnum -> 45 Colt
 
 - type: entity
   name: BaseSMG
@@ -159,7 +160,7 @@
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunVector
   suffix: Deprecated use Drozd
-  description: An excellent fully automatic Heavy SMG. Uses .45 magnum ammo.
+  description: An excellent fully automatic Heavy SMG. Uses 45 Colt ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/vector.rsi
@@ -283,7 +284,7 @@
   name: Vector
   parent: WeaponSubMachineGunVector
   id: WeaponSubMachineGunVectorRubber
-  description: An excellent fully automatic Heavy SMG. Uses .45 magnum ammo.
+  description: An excellent fully automatic Heavy SMG. Uses 45 Colt ammo.
   suffix: Non-Lethal
   components:
   - type: ItemSlots

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/SMGs/smgs.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .35 auto -> 9mm
+
 - type: entity
   name: BaseSMG
   parent: BaseItem
@@ -59,7 +63,7 @@
   name: Atreides
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunAtreides
-  description: Pla-ket-ket-ket-ket! Uses .35 auto ammo.
+  description: Pla-ket-ket-ket-ket! Uses 9mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/atreides.rsi
@@ -82,7 +86,7 @@
   name: C-20r sub machine gun
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunC20r
-  description: A firearm that is often used by the infamous nuclear operatives. Uses .35 auto ammo.
+  description: A firearm that is often used by the infamous nuclear operatives. Uses 9mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/c20r.rsi
@@ -201,7 +205,7 @@
   name: WT550
   parent: BaseWeaponSubMachineGun
   id: WeaponSubMachineGunWt550
-  description: An excellent SMG, produced by NanoTrasen's Small Arms Division. Uses .35 auto ammo.
+  description: An excellent SMG, produced by NanoTrasen's Small Arms Division. Uses 9mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/SMGs/wt550.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .50 -> 12 gauge
+
 - type: entity
   name: BaseWeaponShotgun
   parent: BaseItem
@@ -48,7 +52,7 @@
   # Don't parent to BaseWeaponShotgun because it differs significantly
   parent: BaseItem
   id: WeaponShotgunBulldog
-  description: It's a magazine-fed shotgun designed for close quarters combat. Uses .50 shotgun shells.
+  description: It's a magazine-fed shotgun designed for close quarters combat. Uses 12 gauge shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/bulldog.rsi
@@ -103,7 +107,7 @@
   name: double-barreled shotgun
   parent: BaseWeaponShotgun
   id: WeaponShotgunDoubleBarreled
-  description: An immortal classic. Uses .50 shotgun shells.
+  description: An immortal classic. Uses 12 gauge shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/db_shotgun.rsi
@@ -126,7 +130,7 @@
   name: double-barreled shotgun
   parent: WeaponShotgunDoubleBarreled
   id: WeaponShotgunDoubleBarreledRubber
-  description: An immortal classic. Uses .50 shotgun shells.
+  description: An immortal classic. Uses 12 gauge shotgun shells.
   suffix: Non-Lethal
   components:
   - type: BallisticAmmoProvider
@@ -136,7 +140,7 @@
   name: Enforcer
   parent: BaseWeaponShotgun
   id: WeaponShotgunEnforcer
-  description: A premium combat shotgun based on the Kammerer design, featuring an upgraded clip capacity. .50 shotgun shells.
+  description: A premium combat shotgun based on the Kammerer design, featuring an upgraded clip capacity. 12 gauge shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/enforcer.rsi
@@ -159,7 +163,7 @@
   name: Kammerer
   parent: BaseWeaponShotgun
   id: WeaponShotgunKammerer
-  description: When an old Remington design meets modern materials, this is the result. A favourite weapon of militia forces throughout many worlds. Uses .50 shotgun shells.
+  description: When an old Remington design meets modern materials, this is the result. A favourite weapon of militia forces throughout many worlds. Uses 12 gauge shotgun shells.
   components:
   - type: Item
     size: Normal
@@ -181,7 +185,7 @@
   name: sawn-off shotgun
   parent: BaseWeaponShotgun
   id: WeaponShotgunSawn
-  description: Groovy! Uses .50 shotgun shells.
+  description: Groovy! Uses 12 gauge shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/sawn.rsi
@@ -204,7 +208,7 @@
   name: sawn-off shogun
   parent: WeaponShotgunSawn
   id: WeaponShotgunSawnEmpty
-  description: Groovy! Uses .50 shotgun shells.
+  description: Groovy! Uses 12 gauge shotgun shells.
   suffix: Empty
   components:
   - type: BallisticAmmoProvider
@@ -218,7 +222,7 @@
   name: handmade pistol
   parent: BaseWeaponShotgun
   id: WeaponShotgunHandmade
-  description: Looks unreliable. Uses .50 shotgun shells.
+  description: Looks unreliable. Uses 12 gauge shotgun shells.
   components:
   - type: Item
     size: Small
@@ -262,7 +266,7 @@
   name: improvised shotgun
   parent: BaseWeaponShotgun
   id: WeaponShotgunImprovised
-  description: A shitty, hand-made shotgun that uses .50 shotgun shells. It can only hold one round in the chamber.
+  description: A shitty, hand-made shotgun that uses 12 gauge shotgun shells. It can only hold one round in the chamber.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Shotguns/improvised_shotgun.rsi

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Snipers/snipers.yml
@@ -1,3 +1,7 @@
+# NT14 Change:
+# Standartization of ammo names
+# .30 rifle-> 7.62mm
+
 - type: entity
   name: BaseWeaponSniper
   parent: BaseItem
@@ -41,7 +45,7 @@
   name: Kardashev-Mosin
   parent: BaseWeaponSniper
   id: WeaponSniperMosin
-  description: A weapon for hunting, or endless trench warfare. Uses .30 rifle ammo.
+  description: A weapon for hunting, or endless trench warfare. Uses 7.62mm ammo.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Snipers/bolt_gun_wood.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Changes some ammo names because yes:
.35 Auto -> 9mm
.25 caseless -> 7.62mm caseless
.20 Rifle -> 5.56mm
.30 Rifle -> 7.62mm
.50 -> 12 gauge
.45 magnum -> 45 Colt 


Mightve fucked up in some way or forgot something, not sure tho